### PR TITLE
Update from python3.10 to 3.11

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,21 +23,26 @@ RUN ./gradlew shadowJar \
 
 
 FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND=noninteractive
 # Install dependencies
-RUN apt update && apt install -y --no-install-recommends nmap ncrack ca-certificates openjdk-11-jre wireguard-tools openresolv iptables iproute2 python3-pip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y software-properties-common  \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get remove -y python*
+
+RUN apt update && apt install -y --no-install-recommends nmap ncrack ca-certificates openjdk-11-jre wireguard-tools openresolv iptables iproute2 python3.11 python3.11-dev python3-pip && rm -rf /var/lib/apt/lists/*
 
 COPY --from=tsunami_builder /usr/tsunami /usr/tsunami
 RUN mkdir -p /usr/tsunami/logs
 
 RUN mkdir /install
 WORKDIR /install
+RUN python3.11 -m pip install --upgrade pip
 COPY requirement.txt /requirement.txt
-RUN pip install -r /requirement.txt
-
+RUN python3.11 -m pip install -r /requirement.txt
 
 RUN mkdir -p /app/agent
 ENV PYTHONPATH=/app
 COPY agent /app/agent
 COPY ostorlab.yaml /app/agent/ostorlab.yaml
 WORKDIR /app/agent
-CMD ["python3", "/app/agent/tsunami_agent.py"]
+CMD ["python3.11", "/app/agent/tsunami_agent.py"]

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -1,6 +1,6 @@
 kind: Agent
 name: tsunami
-version: 0.4.4
+version: 0.5.0
 image: images/logo.png
 description: |
   This repository is an implementation of [Ostorlab Agent](https://pypi.org/project/ostorlab/) for the [Tsunami Scanner](https://github.com/google/tsunami-security-scanner) by Google.


### PR DESCRIPTION
**Update from python3.10 to 3.11:**

Steps:
- update python-version in .github/workflows/pylint.yml
- update python-version in .github/workflows/pytest.yml
- update python-version in .github/workflows/mypy.ini
- update python-version in docker file

Steps to test the new version:

- run unit tests using python 3.11 in virtual env

```bash
virtualenv -p python3.11 venv
source venv/bin/activate
pip install -r requirement.txt
pip install -r tests/test-requirement.txt

mypy agent/ tests/
black .
pylint --rcfile=.pylintrc --ignore=tests/ agent/
pylint --rcfile=.pylintrc -d C0103,W0613 tests/
pytest
```

- run test after building the docker image

```bash
ostorlab agent build -f ostorlab.yaml -o dev --no-cache
ostorlab scan run --install --follow=agent/dev/tsunami --agent agent/dev/tsunami ip 8.8.8.8
```