### PR TITLE
Feat : Add CIDR Limit 

### DIFF
--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -1,6 +1,6 @@
 kind: Agent
 name: tsunami
-version: 0.5.0
+version: 0.5.1
 image: images/logo.png
 description: |
   This repository is an implementation of [Ostorlab Agent](https://pypi.org/project/ostorlab/) for the [Tsunami Scanner](https://github.com/google/tsunami-security-scanner) by Google.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,3 +80,43 @@ def ip_small_range_message() -> message.Message:
     selector = "v3.asset.ip.v4"
     msg_data = {"host": "42.42.42.42", "mask": "31", "version": 4}
     return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
+def scan_message_ipv4_with_mask8() -> message.Message:
+    """Creates a message of type v3.asset.ip.v4 to be used by the agent for testing purposes."""
+    selector = "v3.asset.ip.v4"
+    msg_data = {"host": "192.168.1.17", "mask": "8", "version": 4}
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
+def scan_message_ipv4_with_mask16() -> message.Message:
+    """Creates a message of type v3.asset.ip.v4 to be used by the agent for testing purposes."""
+    selector = "v3.asset.ip.v4"
+    msg_data = {"host": "192.168.1.17", "mask": "16", "version": 4}
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
+def scan_message_ipv6_with_mask64() -> message.Message:
+    """Creates a message of type v3.asset.ip.v6 to be used by the agent for testing purposes."""
+    selector = "v3.asset.ip.v6"
+    msg_data = {
+        "host": "2001:db8:3333:4444:5555:6666:7777:8888",
+        "mask": "64",
+        "version": 6,
+    }
+    return message.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
+def scan_message_ipv6_with_mask112() -> message.Message:
+    """Creates a message of type v3.asset.ip.v6 to be used by the agent for testing purposes."""
+    selector = "v3.asset.ip.v6"
+    msg_data = {
+        "host": "2001:db8:3333:4444:5555:6666:7777:8888",
+        "mask": "112",
+        "version": 6,
+    }
+    return message.Message.from_data(selector, data=msg_data)

--- a/tests/factory/tools_test.py
+++ b/tests/factory/tools_test.py
@@ -74,3 +74,29 @@ def testTsunamyFactory_whenPrepareMessages_prepareTarget(
     input_message: message.Message, expected: list[tools.Target]
 ) -> None:
     assert tools.prepare_targets(message=input_message, args={}) == expected
+
+
+def testPrepareTargets_whenIPv4AssetReachCIDRLimit_raiseValueError(
+    scan_message_ipv4_with_mask8: message.Message,
+) -> None:
+    with pytest.raises(ValueError, match="Subnet mask below 16 is not supported."):
+        tools.prepare_targets(message=scan_message_ipv4_with_mask8, args={})
+
+
+def testPrepareTargets_whenIPv4AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
+    scan_message_ipv4_with_mask16: message.Message,
+) -> None:
+    tools.prepare_targets(message=scan_message_ipv4_with_mask16, args={})
+
+
+def testPrepareTargets_whenIPv6AssetReachCIDRLimit_raiseValueError(
+    scan_message_ipv6_with_mask64: message.Message,
+) -> None:
+    with pytest.raises(ValueError, match="Subnet mask below 112 is not supported."):
+        tools.prepare_targets(message=scan_message_ipv6_with_mask64, args={})
+
+
+def testPrepareTargets_whenIPv6AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
+    scan_message_ipv6_with_mask112: message.Message,
+) -> None:
+    tools.prepare_targets(message=scan_message_ipv6_with_mask112, args={})


### PR DESCRIPTION
**Enhancement Request: Set Maximum CIDR Prefix Length for Host Limitation**

**Description:**
In order to ensure controlled and efficient scanning, we propose enhancing the current configuration related to CIDR prefix length for IPv4 and IPv6 addresses.

```python
# Maximum CIDR prefix length to limit the number of hosts that can be scanned.
# For IPv4: Setting it to 16 (allowing for 2^(32-16) - 2 = 65,534 hosts).
# For IPv6: Setting it to 112 (allowing for 2^(128-112) = 65,536 hosts).
IPV4_CIDR_LIMIT = 16
IPV6_CIDR_LIMIT = 112
```

---