### PR TITLE
Fix ValueError(f"Incorrect ip version {version}") and log error instead of raise.

### DIFF
--- a/agent/tsunami/factory/preapre_tagets_tools.py
+++ b/agent/tsunami/factory/preapre_tagets_tools.py
@@ -69,7 +69,7 @@ def _get_ip_version(message: msg.Message) -> int | None:
         ip = ipaddress.ip_address(host)
         version = ip.version
     except ValueError:
-        raise ValueError(f"Invalid IP address: {host}")
+        return None
     return int(version)
 
 
@@ -78,14 +78,17 @@ def _prepare_ip_targets(message: msg.Message, host: str) -> list[Target]:
     ip_version = _get_ip_version(message)
     if ip_version == 6:
         if mask is not None and int(mask) < IPV6_CIDR_LIMIT:
-            raise ValueError(f"Subnet mask below {IPV6_CIDR_LIMIT} is not supported.")
+            logging.error(f"Subnet mask below {IPV6_CIDR_LIMIT} is not supported.")
+            return []
         version = "v6"
     elif ip_version == 4:
         if mask is not None and int(mask) < IPV4_CIDR_LIMIT:
-            raise ValueError(f"Subnet mask below {IPV4_CIDR_LIMIT} is not supported.")
+            logging.error(f"Subnet mask below {IPV6_CIDR_LIMIT} is not supported.")
+            return []
         version = "v4"
     else:
-        raise ValueError(f"Incorrect ip version {ip_version}")
+        logging.error(f"Incorrect ip version {ip_version}")
+        return []
     try:
         if mask is None:
             ip_network = ipaddress.ip_network(host)

--- a/agent/tsunami_agent.py
+++ b/agent/tsunami_agent.py
@@ -77,7 +77,9 @@ class AgentTsunami(
 
         logger.info("Preparing targets ...")
         targets = tools.prepare_targets(message=message, args=self.args)
-
+        if targets is None or len(targets) == 0:
+            logger.info("Invalid target message %s", message)
+            return
         if self._should_process_target(message=message, target=targets[0]) is True:
             logger.info("Scanning targets `%s`.", targets)
             for target in targets:

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -2,7 +2,6 @@
 
 from typing import List
 
-import pytest
 from ostorlab.agent.kb import kb
 from ostorlab.agent.message import message
 from ostorlab.agent.mixins import agent_report_vulnerability_mixin
@@ -14,8 +13,9 @@ from agent import tsunami_agent as ts_agt
 from agent.tsunami.factory import preapre_tagets_tools as tools
 
 
-def testTsunamiAgent_WhenMessageHaveInvalidIpVersion_ShouldRaiseValueErrorException(
+def testTsunamiAgent_WhenMessageHaveInvalidIpVersion_ShouldNotCrash(
     tsunami_agent: ts_agt.AgentTsunami,
+    agent_mock: List[message.Message],
 ) -> None:
     """Test Tsunami agent when receiving a message with invalid ip version.
     Tsunami support ipv4, ipv6 and hostname (domain), therefore every received message
@@ -25,8 +25,9 @@ def testTsunamiAgent_WhenMessageHaveInvalidIpVersion_ShouldRaiseValueErrorExcept
         selector="v3.asset.ip.v4", data={"version": 15631, "host": "0.0.0.0"}
     )
 
-    with pytest.raises(ValueError):
-        tsunami_agent.process(msg)
+    tsunami_agent.process(msg)
+
+    assert len(agent_mock) == 0
 
 
 def testTsunamiAgent_WhenTsunamiScanIsCalled_ShouldRaiseValueErrorException(
@@ -435,3 +436,16 @@ def testAgentTsunami_whenIpNoVersion_shouldNotCrash(
     assert agent_mock[0].data["vulnerability_location"] == {
         "ipv4": {"host": "34.141.29.206", "mask": "32", "version": 4}
     }
+
+
+def testAgentTsunami_whenIpNoTValid_shouldRaiseValueError(
+    tsunami_agent_no_scope: ts_agt.AgentTsunami,
+    agent_mock: List[message.Message],
+) -> None:
+    invalid_ip = message.Message.from_data(
+        "v3.asset.ip.v4", data={"host": "34.141.29", "mask": "32"}
+    )
+
+    tsunami_agent_no_scope.process(invalid_ip)
+
+    assert len(agent_mock) == 0

--- a/tests/factory/tools_test.py
+++ b/tests/factory/tools_test.py
@@ -77,11 +77,13 @@ def testTsunamyFactory_whenPrepareMessages_prepareTarget(
     assert tools.prepare_targets(message=input_message, args={}) == expected
 
 
-def testPrepareTargets_whenIPv4AssetReachCIDRLimit_raiseValueError(
+def testPrepareTargets_whenIPv4AssetReachCIDRLimit_shouldNotScantargets(
     scan_message_ipv4_with_mask8: message.Message,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    with pytest.raises(ValueError, match="Subnet mask below 16 is not supported."):
-        tools.prepare_targets(message=scan_message_ipv4_with_mask8, args={})
+    tools.prepare_targets(message=scan_message_ipv4_with_mask8, args={})
+
+    assert caplog.records[0].message == "Subnet mask below 112 is not supported."
 
 
 def testPrepareTargets_whenIPv4AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
@@ -90,11 +92,13 @@ def testPrepareTargets_whenIPv4AssetDoesNotReachCIDRLimit_doesNotRaiseValueError
     tools.prepare_targets(message=scan_message_ipv4_with_mask16, args={})
 
 
-def testPrepareTargets_whenIPv6AssetReachCIDRLimit_raiseValueError(
+def testPrepareTargets_whenIPv6AssetReachCIDRLimit_ShouldNotScanTarget(
     scan_message_ipv6_with_mask64: message.Message,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    with pytest.raises(ValueError, match="Subnet mask below 112 is not supported."):
-        tools.prepare_targets(message=scan_message_ipv6_with_mask64, args={})
+    tools.prepare_targets(message=scan_message_ipv6_with_mask64, args={})
+
+    assert caplog.records[0].message == "Subnet mask below 112 is not supported."
 
 
 def testPrepareTargets_whenIPv6AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(


### PR DESCRIPTION
This pull request addresses two issues with the agent Trsunami:

1. It manages situations where the IP version is either not provided or set to None.
2. It ensures that when an invalid message is received, we log the error instead of raising an exception.