### PR TITLE
Fix vuln location

### DIFF
--- a/agent/tsunami_agent.py
+++ b/agent/tsunami_agent.py
@@ -246,15 +246,15 @@ class AgentTsunami(
         credentials = []
         for additional_detail in additional_details:
             if "textData" in additional_detail:
-                credentials.append(additional_detail["textData"]["text"])
+                credentials.append(additional_detail.get("textData", {}).get("text"))
             elif "credential" in additional_detail:
                 credentials.append(
-                    f"{additional_detail['credential']['username']}{additional_detail['credential']['password']}"
+                    f"{additional_detail('credential', {}).get('username')}{additional_detail('credential', {}).get('password')}"
                 )
             elif "credentials" in additional_detail:
-                for credential in additional_detail["credentials"]:
+                for credential in additional_detail.get("credentials"):
                     credentials.append(
-                        f"{credential['username']}:{credential['password']}"
+                        f"{credential.get('username')}:{credential.get('password')}"
                     )
 
         return credentials

--- a/agent/tsunami_agent.py
+++ b/agent/tsunami_agent.py
@@ -215,7 +215,7 @@ class AgentTsunami(
             dna=_compute_dna(
                 vuln_title=vulnerability["vulnerability"]["title"],
                 vuln_location=vuln_location,
-                credentials=self.get_credentials(vulnerability["vulnerability"]),
+                credentials=self._get_credentials(vulnerability["vulnerability"]),
             ),
         )
 
@@ -241,7 +241,7 @@ class AgentTsunami(
 
         return technical_detail
 
-    def get_credentials(self, vulnerability: dict[str, Any]) -> list[str]:
+    def _get_credentials(self, vulnerability: dict[str, Any]) -> list[str]:
         additional_details = vulnerability.get("additionalDetails", [])
         credentials = []
         for additional_detail in additional_details:
@@ -249,7 +249,7 @@ class AgentTsunami(
                 credentials.append(additional_detail.get("textData", {}).get("text"))
             elif "credential" in additional_detail:
                 credentials.append(
-                    f"{additional_detail('credential', {}).get('username')}{additional_detail('credential', {}).get('password')}"
+                    f"{additional_detail.get('credential', {}).get('username')}:{additional_detail.get('credential', {}).get('password')}"
                 )
             elif "credentials" in additional_detail:
                 for credential in additional_detail.get("credentials"):

--- a/agent/tsunami_agent.py
+++ b/agent/tsunami_agent.py
@@ -248,19 +248,20 @@ class AgentTsunami(
     ) -> dict[str, Any]:
         additional_details = vulnerability.get("additionalDetails", [])
         credentials = []
-        for additional_detail in additional_details:
-            if "textData" in additional_detail:
-                return {"endpoint": additional_detail.get("textData", {}).get("text")}
-            elif "credential" in additional_detail:
-                credentials.append(
-                    f"{additional_detail.get('credential', {}).get('username')}:{additional_detail.get('credential', {}).get('password')}"
-                )
-            elif "credentials" in additional_detail:
-                for credential in additional_detail.get("credentials"):
-                    credentials.append(
-                        f"{credential.get('username')}:{credential.get('password')}"
-                    )
 
+        for detail in additional_details:
+            if detail.get("textData", {}).get("text") is not None:
+                return {"endpoint": detail.get("textData", {}).get("text")}
+
+            if detail.get("credential") is not None:
+                credentials.append(
+                    f"{detail.get('credential').get('username', '')}:{detail.get('credential').get('password', '')}"
+                )
+
+            for credential in detail.get("credentials", []):
+                credentials.append(
+                    f"{credential.get('username', '')}:{credential.get('password', '')}"
+                )
         return {"credentials": credentials}
 
 

--- a/agent/tsunami_agent.py
+++ b/agent/tsunami_agent.py
@@ -245,7 +245,7 @@ class AgentTsunami(
 
     def _extract_vulnerability_data(
         self, vulnerability: dict[str, Any]
-    ) -> dict[str, Any]:
+    ) -> dict[str, str | list[str]]:
         additional_details = vulnerability.get("additionalDetails", [])
         endpoint = self._extract_endpoint(additional_details)
         if endpoint is not None:

--- a/agent/tsunami_agent.py
+++ b/agent/tsunami_agent.py
@@ -215,7 +215,9 @@ class AgentTsunami(
             dna=_compute_dna(
                 vuln_title=vulnerability["vulnerability"]["title"],
                 vuln_location=vuln_location,
-                details=self._get_credentials(vulnerability["vulnerability"]),
+                details=self._extract_vulnerability_data(
+                    vulnerability["vulnerability"]
+                ),
             ),
         )
 
@@ -241,7 +243,9 @@ class AgentTsunami(
 
         return technical_detail
 
-    def _get_credentials(self, vulnerability: dict[str, Any]) -> dict[str, Any]:
+    def _extract_vulnerability_data(
+        self, vulnerability: dict[str, Any]
+    ) -> dict[str, Any]:
         additional_details = vulnerability.get("additionalDetails", [])
         credentials = []
         for additional_detail in additional_details:

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -522,7 +522,7 @@ def testTsunamiAgent_WhenDomainNameAssetAndTsunamiScanHasCredVulnerabilities_Sho
     )
 
 
-def testTsunamiAgent_WhenDomainNameAssetAndTsunamiScanHasCredsVulnerabilities_ShouldReportVulnerabilities(
+def testTsunamiAgent_whenDomainNameAssetAndTsunamiScanHasCredsVulnerabilities_shouldReportVulnerabilities(
     mocker: plugin.MockerFixture, tsunami_agent: ts_agt.AgentTsunami
 ) -> None:
     """Test Tsunami agent when vulnerabilities are detected.

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -455,7 +455,7 @@ def testAgentTsunami_whenIpNoTValid_shouldRaiseValueError(
     assert len(agent_mock) == 0
 
 
-def testTsunamiAgent_WhenDomainNameAssetAndTsunamiScanHasCredVulnerabilities_ShouldReportVulnerabilities(
+def testTsunamiAgent_WhenDomainNameAssetAndTsunamiScanHasCredVulnerabilities_shouldReportVulnerabilities(
     mocker: plugin.MockerFixture, tsunami_agent: ts_agt.AgentTsunami
 ) -> None:
     """Test Tsunami agent when vulnerabilities are detected.

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -114,7 +114,7 @@ def testTsunamiAgent_WhenTsunamiScanHasVulnerabilities_ShouldReportVulnerabiliti
         vulnerability_location=agent_report_vulnerability_mixin.VulnerabilityLocation(
             metadata=[], asset=ipv4_asset.IPv4(host="0.0.0.0", version=4, mask="32")
         ),
-        dna='{"location": {"ipv4": {"host": "0.0.0.0", "mask": "32", "version": 4}, "metadata": []}, "title": "Ostorlab Platform"}',
+        dna='{"credentials": ["Vulnerable endpoint: \'http://35.81.162.201/heapdump\'"], "location": {"ipv4": {"host": "0.0.0.0", "mask": "32", "version": 4}, "metadata": []}, "title": "Ostorlab Platform"}',
     )
 
 
@@ -185,7 +185,7 @@ def testTsunamiAgent_WhenLinkAssetAndTsunamiScanHasVulnerabilities_ShouldReportV
             ],
             asset=domain_asset.DomainName(name="ostorlab.co"),
         ),
-        dna='{"location": {"domain_name": {"name": "ostorlab.co"}, "metadata": [{"type": "URL", "value": "http://ostorlab.co"}]}, "title": "Ostorlab Platform"}',
+        dna='{"credentials": ["Vulnerable endpoint: \'http://35.81.162.201/heapdump\'"], "location": {"domain_name": {"name": "ostorlab.co"}, "metadata": [{"type": "URL", "value": "http://ostorlab.co"}]}, "title": "Ostorlab Platform"}',
     )
 
 
@@ -256,7 +256,7 @@ def testTsunamiAgent_WhenServiceAssetAndTsunamiScanHasVulnerabilities_ShouldRepo
             ],
             asset=domain_asset.DomainName(name="ostorlab.co"),
         ),
-        dna='{"location": {"domain_name": {"name": "ostorlab.co"}, "metadata": [{"type": "PORT", "value": "6000"}]}, "title": "Ostorlab Platform"}',
+        dna='{"credentials": ["Vulnerable endpoint: \'http://35.81.162.201/heapdump\'"], "location": {"domain_name": {"name": "ostorlab.co"}, "metadata": [{"type": "PORT", "value": "6000"}]}, "title": "Ostorlab Platform"}',
     )
 
 
@@ -327,7 +327,7 @@ def testTsunamiAgent_WhenDomainNameAssetAndTsunamiScanHasVulnerabilities_ShouldR
             ],
             asset=domain_asset.DomainName(name="ostorlab.co"),
         ),
-        dna='{"location": {"domain_name": {"name": "ostorlab.co"}, "metadata": [{"type": "URL", "value": "http://ostorlab.co"}]}, "title": "Ostorlab Platform"}',
+        dna='{"credentials": ["Vulnerable endpoint: \'http://35.81.162.201/heapdump\'"], "location": {"domain_name": {"name": "ostorlab.co"}, "metadata": [{"type": "URL", "value": "http://ostorlab.co"}]}, "title": "Ostorlab Platform"}',
     )
 
 

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -114,7 +114,7 @@ def testTsunamiAgent_WhenTsunamiScanHasVulnerabilities_ShouldReportVulnerabiliti
         vulnerability_location=agent_report_vulnerability_mixin.VulnerabilityLocation(
             metadata=[], asset=ipv4_asset.IPv4(host="0.0.0.0", version=4, mask="32")
         ),
-        dna='{"credentials": ["Vulnerable endpoint: \'http://35.81.162.201/heapdump\'"], "location": {"ipv4": {"host": "0.0.0.0", "mask": "32", "version": 4}, "metadata": []}, "title": "Ostorlab Platform"}',
+        dna='{"endpoint": "Vulnerable endpoint: \'http://35.81.162.201/heapdump\'", "location": {"ipv4": {"host": "0.0.0.0", "mask": "32", "version": 4}, "metadata": []}, "title": "Ostorlab Platform"}',
     )
 
 
@@ -185,7 +185,7 @@ def testTsunamiAgent_WhenLinkAssetAndTsunamiScanHasVulnerabilities_ShouldReportV
             ],
             asset=domain_asset.DomainName(name="ostorlab.co"),
         ),
-        dna='{"credentials": ["Vulnerable endpoint: \'http://35.81.162.201/heapdump\'"], "location": {"domain_name": {"name": "ostorlab.co"}, "metadata": [{"type": "URL", "value": "http://ostorlab.co"}]}, "title": "Ostorlab Platform"}',
+        dna='{"endpoint": "Vulnerable endpoint: \'http://35.81.162.201/heapdump\'", "location": {"domain_name": {"name": "ostorlab.co"}, "metadata": [{"type": "URL", "value": "http://ostorlab.co"}]}, "title": "Ostorlab Platform"}',
     )
 
 
@@ -256,7 +256,7 @@ def testTsunamiAgent_WhenServiceAssetAndTsunamiScanHasVulnerabilities_ShouldRepo
             ],
             asset=domain_asset.DomainName(name="ostorlab.co"),
         ),
-        dna='{"credentials": ["Vulnerable endpoint: \'http://35.81.162.201/heapdump\'"], "location": {"domain_name": {"name": "ostorlab.co"}, "metadata": [{"type": "PORT", "value": "6000"}]}, "title": "Ostorlab Platform"}',
+        dna='{"endpoint": "Vulnerable endpoint: \'http://35.81.162.201/heapdump\'", "location": {"domain_name": {"name": "ostorlab.co"}, "metadata": [{"type": "PORT", "value": "6000"}]}, "title": "Ostorlab Platform"}',
     )
 
 
@@ -327,7 +327,7 @@ def testTsunamiAgent_WhenDomainNameAssetAndTsunamiScanHasVulnerabilities_ShouldR
             ],
             asset=domain_asset.DomainName(name="ostorlab.co"),
         ),
-        dna='{"credentials": ["Vulnerable endpoint: \'http://35.81.162.201/heapdump\'"], "location": {"domain_name": {"name": "ostorlab.co"}, "metadata": [{"type": "URL", "value": "http://ostorlab.co"}]}, "title": "Ostorlab Platform"}',
+        dna='{"endpoint": "Vulnerable endpoint: \'http://35.81.162.201/heapdump\'", "location": {"domain_name": {"name": "ostorlab.co"}, "metadata": [{"type": "URL", "value": "http://ostorlab.co"}]}, "title": "Ostorlab Platform"}',
     )
 
 

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -453,3 +453,137 @@ def testAgentTsunami_whenIpNoTValid_shouldRaiseValueError(
     tsunami_agent_no_scope.process(invalid_ip)
 
     assert len(agent_mock) == 0
+
+
+def testTsunamiAgent_WhenDomainNameAssetAndTsunamiScanHasCredVulnerabilities_ShouldReportVulnerabilities(
+    mocker: plugin.MockerFixture, tsunami_agent: ts_agt.AgentTsunami
+) -> None:
+    """Test Tsunami agent when vulnerabilities are detected.
+    Tsunami supports ipv4, ipv6 and hostname (domain), therefore every received message
+    should have a valid ip version, other-ways the agent should raise a ValueError exception.
+    """
+
+    data = {
+        "scanStatus": "SUCCEEDED",
+        "vulnerabilities": [
+            {
+                "vulnerability": {
+                    "title": "Ostorlab Platform",
+                    "description": "Ostorlab is not password protected",
+                    "severity": "HIGH",
+                    "additionalDetails": [
+                        {"credential": {"username": "user", "password": "password"}}
+                    ],
+                }
+            }
+        ],
+    }
+    risk_rating = "HIGH"
+    description = "Ostorlab is not password protected"
+    kb_entry = kb.Entry(
+        title="Ostorlab Platform",
+        risk_rating=risk_rating,
+        short_description=description,
+        description=description,
+        recommendation="",
+        references={},
+        security_issue=True,
+        privacy_issue=False,
+        has_public_exploit=True,
+        targeted_by_malware=True,
+        targeted_by_ransomware=True,
+        targeted_by_nation_state=True,
+    )
+
+    mocker.patch("agent.tsunami.tsunami.Tsunami.scan", return_value=data)
+    mock_report_vulnerability = mocker.patch(
+        "agent.tsunami_agent.AgentTsunami.report_vulnerability", return_value=None
+    )
+    msg = message.Message.from_data(
+        selector="v3.asset.domain_name", data={"name": "ostorlab.co"}
+    )
+
+    tsunami_agent.process(msg)
+
+    mock_report_vulnerability.assert_called_once_with(
+        entry=kb_entry,
+        technical_detail="The extracted credential for the vulnerable network service: user:password \n",
+        risk_rating=agent_report_vulnerability_mixin.RiskRating.HIGH,
+        vulnerability_location=agent_report_vulnerability_mixin.VulnerabilityLocation(
+            metadata=[
+                agent_report_vulnerability_mixin.VulnerabilityLocationMetadata(
+                    agent_report_vulnerability_mixin.MetadataType.URL,
+                    "http://ostorlab.co",
+                )
+            ],
+            asset=domain_asset.DomainName(name="ostorlab.co"),
+        ),
+        dna='{"credentials": ["user:password"], "location": {"domain_name": {"name": "ostorlab.co"}, "metadata": [{"type": "URL", "value": "http://ostorlab.co"}]}, "title": "Ostorlab Platform"}',
+    )
+
+
+def testTsunamiAgent_WhenDomainNameAssetAndTsunamiScanHasCredsVulnerabilities_ShouldReportVulnerabilities(
+    mocker: plugin.MockerFixture, tsunami_agent: ts_agt.AgentTsunami
+) -> None:
+    """Test Tsunami agent when vulnerabilities are detected.
+    Tsunami supports ipv4, ipv6 and hostname (domain), therefore every received message
+    should have a valid ip version, other-ways the agent should raise a ValueError exception.
+    """
+
+    data = {
+        "scanStatus": "SUCCEEDED",
+        "vulnerabilities": [
+            {
+                "vulnerability": {
+                    "title": "Ostorlab Platform",
+                    "description": "Ostorlab is not password protected",
+                    "severity": "HIGH",
+                    "additionalDetails": [
+                        {"credentials": [{"username": "user", "password": "password"}]}
+                    ],
+                }
+            }
+        ],
+    }
+    risk_rating = "HIGH"
+    description = "Ostorlab is not password protected"
+    kb_entry = kb.Entry(
+        title="Ostorlab Platform",
+        risk_rating=risk_rating,
+        short_description=description,
+        description=description,
+        recommendation="",
+        references={},
+        security_issue=True,
+        privacy_issue=False,
+        has_public_exploit=True,
+        targeted_by_malware=True,
+        targeted_by_ransomware=True,
+        targeted_by_nation_state=True,
+    )
+
+    mocker.patch("agent.tsunami.tsunami.Tsunami.scan", return_value=data)
+    mock_report_vulnerability = mocker.patch(
+        "agent.tsunami_agent.AgentTsunami.report_vulnerability", return_value=None
+    )
+    msg = message.Message.from_data(
+        selector="v3.asset.domain_name", data={"name": "ostorlab.co"}
+    )
+
+    tsunami_agent.process(msg)
+
+    mock_report_vulnerability.assert_called_once_with(
+        entry=kb_entry,
+        technical_detail="The extracted credential for the vulnerable network service: user:password \n",
+        risk_rating=agent_report_vulnerability_mixin.RiskRating.HIGH,
+        vulnerability_location=agent_report_vulnerability_mixin.VulnerabilityLocation(
+            metadata=[
+                agent_report_vulnerability_mixin.VulnerabilityLocationMetadata(
+                    agent_report_vulnerability_mixin.MetadataType.URL,
+                    "http://ostorlab.co",
+                )
+            ],
+            asset=domain_asset.DomainName(name="ostorlab.co"),
+        ),
+        dna='{"credentials": ["user:password"], "location": {"domain_name": {"name": "ostorlab.co"}, "metadata": [{"type": "URL", "value": "http://ostorlab.co"}]}, "title": "Ostorlab Platform"}',
+    )


### PR DESCRIPTION
In this PR, I have fixed the vulnerability location by including the tsunami-found credentials for that location, as many vulnerabilities can exist in the same path that the previous implementation would have excluded them.

How is DNA calculated:
The function constructs a dictionary `dna_data` of:
- Vulnerability title (vuln_title)
- Vulnerability location (vuln_location)
- Details (tsunami results).

and returns a JSON string of the dna_data dictionary, sorted by keys.
