### PR TITLE
feature: migrate to Python 3.14 and modernize Docker build

### DIFF
--- a/.github/workflows/lint_format_checker.yaml
+++ b/.github/workflows/lint_format_checker.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.14" ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.14"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/typing_checker.yaml
+++ b/.github/workflows/typing_checker.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.14" ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+python_version = 3.14
 files = agent, tests
 check_untyped_defs = True
 follow_imports_for_stubs = True

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,22 @@
-#Stage 1.
-FROM adoptopenjdk/openjdk13:debianslim as tsunami_builder
+FROM ghcr.io/google/tsunami-scanner-full:latest
 
-## Install dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates
-
-# Clone the plugins repo
-WORKDIR /usr/tsunami/repos
-RUN git clone --depth 1 "https://github.com/google/tsunami-security-scanner-plugins"
-
-# Build plugins
-WORKDIR /usr/tsunami/repos/tsunami-security-scanner-plugins/google
-RUN chmod +x build_all.sh && ./build_all.sh
-
-RUN mkdir /usr/tsunami/plugins && cp build/plugins/*.jar /usr/tsunami/plugins
-
-# Compile the Tsunami scanner
-RUN git clone --depth 1 "https://github.com/google/tsunami-security-scanner.git" /usr/repos/tsunami-security-scanner
-WORKDIR /usr/repos/tsunami-security-scanner
-RUN ./gradlew shadowJar \
-    && cp $(find "./" -name 'tsunami-main-*-cli.jar') /usr/tsunami/tsunami.jar \
-    && cp ./tsunami.yaml /usr/tsunami
-
-
-FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
-# Install dependencies
-RUN apt-get update && apt-get install -y software-properties-common  \
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        software-properties-common \
     && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get remove -y python*
+    && apt-get update && apt-get install -y --no-install-recommends \
+        nmap ncrack wireguard-tools iptables iproute2 \
+        python3.14 python3.14-dev python3.14-venv \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN apt update && apt install -y --no-install-recommends nmap ncrack ca-certificates openjdk-11-jre wireguard-tools openresolv iptables iproute2 python3.11 python3.11-dev python3-pip && rm -rf /var/lib/apt/lists/*
-
-COPY --from=tsunami_builder /usr/tsunami /usr/tsunami
-RUN mkdir -p /usr/tsunami/logs
-
-RUN mkdir /install
-WORKDIR /install
-RUN python3.11 -m pip install --upgrade pip
+RUN python3.14 -m venv /app/venv
 COPY requirement.txt /requirement.txt
-RUN python3.11 -m pip install -r /requirement.txt
+RUN /app/venv/bin/pip install --upgrade pip && /app/venv/bin/pip install -r /requirement.txt
 
 RUN mkdir -p /app/agent
 ENV PYTHONPATH=/app
 COPY agent /app/agent
 COPY ostorlab.yaml /app/agent/ostorlab.yaml
 WORKDIR /app/agent
-CMD ["python3.11", "/app/agent/tsunami_agent.py"]
+CMD ["/app/venv/bin/python", "/app/agent/tsunami_agent.py"]

--- a/agent/tsunami/tsunami.py
+++ b/agent/tsunami/tsunami.py
@@ -69,7 +69,7 @@ class Tsunami:
             "java",
             "-cp",
             "/usr/tsunami/tsunami.jar:/usr/tsunami/plugins/*",
-            "-Dtsunami-config.location=/usr/tsunami/tsunami.yaml",
+            "-Dtsunami.config.location=/usr/tsunami/tsunami.yaml",
             "com.google.tsunami.main.cli.TsunamiCli",
             "--scan-results-local-output-format=JSON",
             f"--scan-results-local-output-filename={output_file}",

--- a/agent/tsunami/tsunami.py
+++ b/agent/tsunami/tsunami.py
@@ -54,7 +54,7 @@ class Tsunami:
         else:
             raise ValueError("Could not find any target.")
 
-    @func_timeout.func_set_timeout(TIMEOUT)  # type: ignore[misc]
+    @func_timeout.func_set_timeout(TIMEOUT)  # type: ignore[untyped-decorator]
     def _start_scan(self, target: tools.Target, output_file: str) -> None:
         """Run a tsunami scan using python subprocess.
 

--- a/agent/tsunami_agent.py
+++ b/agent/tsunami_agent.py
@@ -327,9 +327,9 @@ def _sort_dict(d: dict[str, Any] | list[Any]) -> dict[str, Any] | list[Any]:
     if isinstance(d, list):
         return sorted(
             d,
-            key=lambda x: json.dumps(x, sort_keys=True)
-            if isinstance(x, dict)
-            else str(x),
+            key=lambda x: (
+                json.dumps(x, sort_keys=True) if isinstance(x, dict) else str(x)
+            ),
         )
     return d
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,1 +1,2 @@
 #This file will be used if we want to customize the Ruff configuration.
+target-version = "py314"


### PR DESCRIPTION
## What
Upgrade the agent runtime from Python 3.11 to Python 3.14 and replace the outdated self-built Docker image with the official `ghcr.io/google/tsunami-scanner-full` base image.

## Why
- `adoptopenjdk/openjdk13:debianslim` (used in the old builder stage) is based on Debian Buster, which reached EOL — its apt repos return 404, making the image impossible to build.
- The tsunami-security-scanner-plugins repo was restructured: `google/build_all.sh` no longer exists, breaking the plugin compilation step entirely.
- Python 3.11 is aging; 3.14 brings performance improvements and keeps the agent on a supported release track.

## How
- Swap the two-stage build-from-source approach for a single-stage build on top of `ghcr.io/google/tsunami-scanner-full:latest`, which already ships the compiled `tsunami.jar`, all plugins, and Java 21.
- Install Python 3.14 via the deadsnakes PPA, isolate dependencies in a venv (`/app/venv`) to avoid conflicts with system packages in the base image.
- Fix the Tsunami JVM config flag: `-Dtsunami-config.location` → `-Dtsunami.config.location` (hyphen → dot) to match the updated scanner.

## Changes
- `Dockerfile` — replaced two-stage from-source build with single-stage on `tsunami-scanner-full`; added deadsnakes PPA, Python 3.14 venv, dropped `openresolv` (unavailable on Ubuntu 24.04)
- `agent/tsunami/tsunami.py` — updated JVM flag `-Dtsunami-config.location` → `-Dtsunami.config.location`
- `.github/workflows/pytest.yml` — matrix python-version `3.11` → `3.14`
- `.github/workflows/typing_checker.yaml` — matrix python-version `3.11` → `3.14`
- `.github/workflows/lint_format_checker.yaml` — matrix python-version `3.11` → `3.14`
- `.mypy.ini` — added `python_version = 3.14`
- `ruff.toml` — added `target-version = "py314"`

## Local build
<img width="493" height="85" alt="image" src="https://github.com/user-attachments/assets/d8789e1f-47bf-42c3-8a58-dc571d4876eb" />

## Local run
<img width="1462" height="627" alt="image" src="https://github.com/user-attachments/assets/ec685f65-922c-44bb-95dd-ec43b3d6ba11" />

