### PR TITLE
fix: replace tsunami-scanner-full base with explicit COPY stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
-FROM ghcr.io/google/tsunami-scanner-full:latest
+FROM ghcr.io/google/tsunami-scanner-core:latest AS core
+FROM ghcr.io/google/tsunami-plugins-google:latest AS plugins-google
+FROM ghcr.io/google/tsunami-plugins-templated:latest AS plugins-templated
+FROM ghcr.io/google/tsunami-plugins-doyensec:latest AS plugins-doyensec
+FROM ghcr.io/google/tsunami-plugins-community:latest AS plugins-community
+FROM ghcr.io/google/tsunami-plugins-govtech:latest AS plugins-govtech
+FROM ghcr.io/google/tsunami-plugins-facebook:latest AS plugins-facebook
+FROM ghcr.io/google/tsunami-plugins-python:latest AS plugins-python
+
+FROM ubuntu:latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -6,9 +15,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         software-properties-common \
     && add-apt-repository ppa:deadsnakes/ppa \
     && apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates openjdk-21-jre \
         nmap ncrack wireguard-tools iptables iproute2 \
         python3.14 python3.14-dev python3.14-venv \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=core /usr/tsunami/ /usr/tsunami/
+COPY --from=plugins-google /usr/tsunami/plugins/ /usr/tsunami/plugins/
+COPY --from=plugins-templated /usr/tsunami/plugins/ /usr/tsunami/plugins/
+COPY --from=plugins-doyensec /usr/tsunami/plugins/ /usr/tsunami/plugins/
+COPY --from=plugins-community /usr/tsunami/plugins/ /usr/tsunami/plugins/
+COPY --from=plugins-govtech /usr/tsunami/plugins/ /usr/tsunami/plugins/
+COPY --from=plugins-facebook /usr/tsunami/plugins/ /usr/tsunami/plugins/
+COPY --from=plugins-python /usr/tsunami/py_plugins/ /usr/tsunami/py_plugins/
+RUN mkdir -p /usr/tsunami/logs
 
 RUN python3.14 -m venv /app/venv
 COPY requirement.txt /requirement.txt


### PR DESCRIPTION
## What
Replace `FROM ghcr.io/google/tsunami-scanner-full:latest` with individual `COPY --from` stages into a clean `ubuntu:latest` base.

## Why
Using `ghcr.io/google/tsunami-scanner-full:latest` as a direct base caused the OXO registry push to fail with `NotFound: content digest ... not found`. When the final image is based on a GHCR image, Docker tries to cross-mount those layers into OXO's registry — which isn't supported, breaking the cloud build pipeline.

## How
Mirror the structure of the official `full.Dockerfile`: pull artifacts from individual GHCR plugin images using `COPY --from` into a `ubuntu:latest` base. The final image only contains locally-built layers, making it fully pushable to any registry.

## Changes
- `Dockerfile` — replaced single `FROM ghcr.io/google/tsunami-scanner-full:latest` with 8 builder stages (`core`, `plugins-google`, `plugins-templated`, `plugins-doyensec`, `plugins-community`, `plugins-govtech`, `plugins-facebook`, `plugins-python`) and a `ubuntu:latest` runtime base with explicit `COPY --from` directives; added `ca-certificates` and `openjdk-21-jre` to the apt install

## Local build & run
<img width="1349" height="708" alt="image" src="https://github.com/user-attachments/assets/a8710440-ed80-4083-b3f8-29bbaecb53b8" />